### PR TITLE
chore: release v0.3.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.3.6](https://github.com/hseeberger/api-version/compare/v0.3.5...v0.3.6) - 2026-04-17
+
+### Other
+
+- *(deps)* bump taiki-e/install-action in the all group ([#66](https://github.com/hseeberger/api-version/pull/66))
+- *(deps)* update Rust to 1.94.1 ([#65](https://github.com/hseeberger/api-version/pull/65))
+- *(deps)* bump taiki-e/install-action in the all group ([#64](https://github.com/hseeberger/api-version/pull/64))
+- *(deps)* bump Rust to 1.94.0
+- *(deps)* bump dtolnay/rust-toolchain in the all group ([#61](https://github.com/hseeberger/api-version/pull/61))
+- *(ci)* add cooldown to dependabot
+- *(deps)* bump taiki-e/install-action from 2.69.10 to 2.69.12 ([#60](https://github.com/hseeberger/api-version/pull/60))
+- *(deps)* bump futures from 0.3.31 to 0.3.32 ([#57](https://github.com/hseeberger/api-version/pull/57))
+- *(deps)* bump tokio from 1.48.0 to 1.50.0 ([#56](https://github.com/hseeberger/api-version/pull/56))
+- *(deps)* bump anyhow from 1.0.100 to 1.0.102 ([#55](https://github.com/hseeberger/api-version/pull/55))
+- *(deps)* bump taiki-e/install-action from 2.69.9 to 2.69.10 ([#54](https://github.com/hseeberger/api-version/pull/54))
+
 ## [0.3.5](https://github.com/hseeberger/api-version/compare/v0.3.4...v0.3.5) - 2026-03-25
 
 ### Other

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -19,7 +19,7 @@ checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
 name = "api-version"
-version = "0.3.5"
+version = "0.3.6"
 dependencies = [
  "anyhow",
  "assert_matches",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name          = "api-version"
-version       = "0.3.5"
+version       = "0.3.6"
 edition       = "2024"
 description   = "Axum middleware to add a version prefix to request paths based on a set of versions and an optional `x-api-version` header"
 authors       = [ "Heiko Seeberger <git@heikoseeberger.de>" ]


### PR DESCRIPTION



## 🤖 New release

* `api-version`: 0.3.5 -> 0.3.6 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.3.6](https://github.com/hseeberger/api-version/compare/v0.3.5...v0.3.6) - 2026-04-17

### Other

- *(deps)* bump taiki-e/install-action in the all group ([#66](https://github.com/hseeberger/api-version/pull/66))
- *(deps)* update Rust to 1.94.1 ([#65](https://github.com/hseeberger/api-version/pull/65))
- *(deps)* bump taiki-e/install-action in the all group ([#64](https://github.com/hseeberger/api-version/pull/64))
- *(deps)* bump Rust to 1.94.0
- *(deps)* bump dtolnay/rust-toolchain in the all group ([#61](https://github.com/hseeberger/api-version/pull/61))
- *(ci)* add cooldown to dependabot
- *(deps)* bump taiki-e/install-action from 2.69.10 to 2.69.12 ([#60](https://github.com/hseeberger/api-version/pull/60))
- *(deps)* bump futures from 0.3.31 to 0.3.32 ([#57](https://github.com/hseeberger/api-version/pull/57))
- *(deps)* bump tokio from 1.48.0 to 1.50.0 ([#56](https://github.com/hseeberger/api-version/pull/56))
- *(deps)* bump anyhow from 1.0.100 to 1.0.102 ([#55](https://github.com/hseeberger/api-version/pull/55))
- *(deps)* bump taiki-e/install-action from 2.69.9 to 2.69.10 ([#54](https://github.com/hseeberger/api-version/pull/54))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).