### PR TITLE
build: remove dev container support

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -18,7 +18,8 @@ jobs:
     name: Setup Rust toolchain
     runs-on: ubuntu-latest
     outputs:
-      toolchain: ${{steps.set_toolchain.outputs.toolchain}}
+      stable: ${{steps.set_toolchain.outputs.stable}}
+      nightly: ${{steps.set_toolchain.outputs.nightly}}
     steps:
       - name: Checkout repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -28,12 +29,15 @@ jobs:
         env:
           toolchain_toml: "rust-toolchain.toml"
         run: |
-          toolchain=$(grep channel rust-toolchain.toml | sed -r 's/channel = "(.*)"/\1/')
-          echo "toolchain=$toolchain" | tee -a "$GITHUB_OUTPUT"
+          stable=$(grep channel rust-toolchain.toml | sed -r 's/channel = "(.*)"/\1/')
+          echo "stable=$stable" | tee -a "$GITHUB_OUTPUT"
+          nightly=$(rustc --version | grep -oE '[0-9]{4}-[0-9]{2}-[0-9]{2}' | sed 's/^/nightly-/')
+          echo "nightly=$nightly" | tee -a "$GITHUB_OUTPUT"
 
   fmt-check:
     name: Check Code Format
     runs-on: ubuntu-latest
+    needs: toolchain
     steps:
       - name: Checkout repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -41,7 +45,7 @@ jobs:
       - name: Install Rust
         uses: dtolnay/rust-toolchain@3c5f7ea28cd621ae0bf5283f0e981fb97b8a7af9
         with:
-          toolchain: nightly-2025-12-08
+          toolchain: ${{needs.toolchain.outputs.nightly}}
           components: rustfmt
 
       - name: Install just
@@ -67,7 +71,7 @@ jobs:
       - name: Install Rust
         uses: dtolnay/rust-toolchain@3c5f7ea28cd621ae0bf5283f0e981fb97b8a7af9
         with:
-          toolchain: ${{needs.toolchain.outputs.toolchain}}
+          toolchain: ${{needs.toolchain.outputs.stable}}
           components: clippy
 
       - name: Install just
@@ -80,7 +84,7 @@ jobs:
 
       - name: just lint
         run: |
-          rustup override set ${{needs.toolchain.outputs.toolchain}}
+          rustup override set ${{needs.toolchain.outputs.stable}}
           just lint
 
   test:
@@ -94,7 +98,7 @@ jobs:
       - name: Install Rust
         uses: dtolnay/rust-toolchain@3c5f7ea28cd621ae0bf5283f0e981fb97b8a7af9
         with:
-          toolchain: ${{needs.toolchain.outputs.toolchain}}
+          toolchain: ${{needs.toolchain.outputs.stable}}
 
       - name: Install just
         uses: taiki-e/install-action@58e862542551f667fa44c8a2a4a1d64ad477c96a # v2.75.17
@@ -106,7 +110,7 @@ jobs:
 
       - name: just test
         run: |
-          rustup override set ${{needs.toolchain.outputs.toolchain}}
+          rustup override set ${{needs.toolchain.outputs.stable}}
           just test
 
   doc:
@@ -120,7 +124,7 @@ jobs:
       - name: Install Rust
         uses: dtolnay/rust-toolchain@3c5f7ea28cd621ae0bf5283f0e981fb97b8a7af9
         with:
-          toolchain: ${{needs.toolchain.outputs.toolchain}}
+          toolchain: ${{needs.toolchain.outputs.stable}}
           components: rust-docs
 
       - name: Install just

--- a/justfile
+++ b/justfile
@@ -1,7 +1,6 @@
 set shell := ["bash", "-uc"]
 
-rust_version := `grep channel rust-toolchain.toml | sed -r 's/channel = "(.*)"/\1/'`
-nightly := "nightly-2025-12-08"
+nightly := `rustc --version | grep -oE '[0-9]{4}-[0-9]{2}-[0-9]{2}' | sed 's/^/nightly-/'`
 
 check:
 	cargo check --tests


### PR DESCRIPTION
## Summary

- Remove unused `rust_version` variable from justfile
- Derive `nightly` toolchain dynamically from the active `rustc` version instead of hardcoding it

🤖 Generated with [Claude Code](https://claude.com/claude-code)