### PR TITLE
chore: release v0.3.7

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.3.7](https://github.com/hseeberger/api-version/compare/v0.3.6...v0.3.7) - 2026-06-01
+
+### Other
+
+- bump rustfmt edition to 2024 ([#88](https://github.com/hseeberger/api-version/pull/88))
+
 ## [0.3.6](https://github.com/hseeberger/api-version/compare/v0.3.5...v0.3.6) - 2026-05-29
 
 ### Other

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -19,7 +19,7 @@ checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
 name = "api-version"
-version = "0.3.6"
+version = "0.3.7"
 dependencies = [
  "anyhow",
  "assert_matches",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name          = "api-version"
-version       = "0.3.6"
+version       = "0.3.7"
 edition       = "2024"
 description   = "Axum middleware to add a version prefix to request paths based on a set of versions and an optional `x-api-version` header"
 authors       = [ "Heiko Seeberger <git@heikoseeberger.de>" ]


### PR DESCRIPTION



## 🤖 New release

* `api-version`: 0.3.6 -> 0.3.7 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.3.7](https://github.com/hseeberger/api-version/compare/v0.3.6...v0.3.7) - 2026-06-01

### Other

- bump rustfmt edition to 2024 ([#88](https://github.com/hseeberger/api-version/pull/88))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).