### PR TITLE
chore: standardize project scaffolding and package metadata

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,6 @@
 .DS_Store
+.claude
+.envrc.local
 .vscode
 .zed
 target

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,14 +1,14 @@
 [package]
 name          = "api-version"
+description   = "Axum middleware to add a version prefix to request paths based on a set of versions and an optional `x-api-version` header"
 version       = "0.3.7"
 edition       = "2024"
-description   = "Axum middleware to add a version prefix to request paths based on a set of versions and an optional `x-api-version` header"
-authors       = [ "Heiko Seeberger <git@heikoseeberger.de>" ]
 license       = "Apache-2.0"
 readme        = "README.md"
 homepage      = "https://github.com/hseeberger/api-version"
 repository    = "https://github.com/hseeberger/api-version"
-documentation = "https://github.com/hseeberger/api-version"
+documentation = "https://docs.rs/api-version/latest/api_version/"
+publish       = true
 
 [dependencies]
 axum       = { version = "0.8" }

--- a/justfile
+++ b/justfile
@@ -3,27 +3,28 @@ set shell := ["bash", "-uc"]
 nightly := `rustc --version | grep -oE '[0-9]{4}-[0-9]{2}-[0-9]{2}' | sed 's/^/nightly-/'`
 
 check:
-	cargo check --tests
+    cargo check --tests
 
 fix:
-	cargo fix --tests --allow-dirty --allow-staged
+    cargo fix --tests --allow-dirty --allow-staged
 
 fmt:
-    cargo +{{nightly}} fmt
+    cargo +{{ nightly }} fmt
+    RUST_LOG=error taplo fmt
 
 fmt-check:
-    cargo +{{nightly}} fmt --check
+    cargo +{{ nightly }} fmt --check
 
 lint:
-	cargo clippy --tests --no-deps -- -D warnings
+    cargo clippy --tests --no-deps -- -D warnings
 
 lint-fix:
-	cargo clippy --tests --no-deps --allow-dirty --allow-staged --fix
+    cargo clippy --tests --no-deps --allow-dirty --allow-staged --fix
 
 test:
-	cargo test --tests
+    cargo test --tests
 
 doc:
-	cargo doc --no-deps
+    cargo doc --no-deps
 
 all: check fmt lint test doc


### PR DESCRIPTION
Standardize scaffolding, CI config, and package metadata to the shared template.

- `justfile`: 4-space indentation, `taplo fmt` in the `fmt` recipe
- `.gitignore`: canonical entries, sorted
- `Cargo.toml`: SPDX license, no `authors`, docs.rs `documentation`, consistent field order, explicit `publish`
- workflows / rustfmt edition aligned where applicable

🤖 Generated with [Claude Code](https://claude.com/claude-code)