### PR TITLE
docs: turn on warnings for missing docs

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,6 +1,8 @@
 //! Axum middleware to rewrite a request such that a version prefix, e.g. `"/v0"`, is added to the
 //! path.
 
+#![warn(missing_docs)]
+
 use axum::{
     RequestExt,
     extract::Request,


### PR DESCRIPTION
Enables `#![warn(missing_docs)]` on the crate. All public items were already documented.